### PR TITLE
Fix mean in data scaling

### DIFF
--- a/src/pipeline/data_splits.ipynb
+++ b/src/pipeline/data_splits.ipynb
@@ -9,19 +9,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
     "from sklearn.model_selection import train_test_split\n",
-    "from pyprojroot import here\n"
+    "from pyprojroot import here\n",
+    "from sklearn.preprocessing import StandardScaler\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -61,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -97,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -137,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -164,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,19 +182,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create std scaler for X\n",
+    "scaler = StandardScaler().fit(X_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "quality_variation     -571.166825\n",
-      "Air temperature        -41.265902\n",
-      "Process temperature    -49.012921\n",
-      "Rotational speed         6.395058\n",
-      "Torque                 -34.373824\n",
-      "Tool wear               -4.313942\n",
+      "quality_variation      5.495597e-17\n",
+      "Air temperature        1.912799e-14\n",
+      "Process temperature   -6.398817e-15\n",
+      "Rotational speed       1.478126e-16\n",
+      "Torque                -2.529869e-16\n",
+      "Tool wear             -7.864388e-17\n",
       "dtype: float64\n",
       "-----------------\n",
       "quality_variation      1.000067\n",
@@ -204,18 +215,10 @@
       "Tool wear              1.000067\n",
       "dtype: float64\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/jubacochran/projects/student/207/w207-predictive-maintenance/.venv/lib/python3.12/site-packages/numpy/_core/fromnumeric.py:4062: FutureWarning: The behavior of DataFrame.std with axis=None is deprecated, in a future version this will reduce over both axes and return a scalar. To retain the old behavior, pass axis=0 (or do not pass axis)\n",
-      "  return std(axis=axis, dtype=dtype, out=out, ddof=ddof, **kwargs)\n"
-     ]
     }
    ],
    "source": [
-    "X_train_scaled = (X_train - np.mean(X_train))/np.std(X_train)\n",
+    "X_train_scaled = pd.DataFrame(scaler.transform(X_train), columns=X_train.columns)\n",
     "\n",
     "print(X_train_scaled.mean())\n",
     "print('-----------------')\n",
@@ -224,19 +227,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "quality_variation     -571.136560\n",
-      "Air temperature        -41.260979\n",
-      "Process temperature    -49.026535\n",
-      "Rotational speed         6.409401\n",
-      "Torque                 -34.403268\n",
-      "Tool wear               -4.332920\n",
+      "quality_variation      0.030265\n",
+      "Air temperature        0.004923\n",
+      "Process temperature   -0.013613\n",
+      "Rotational speed       0.014343\n",
+      "Torque                -0.029444\n",
+      "Tool wear             -0.018978\n",
       "dtype: float64\n",
       "-----------------\n",
       "quality_variation      1.029998\n",
@@ -250,7 +253,7 @@
     }
    ],
    "source": [
-    "X_val_scaled = (X_val - np.mean(X_train))/np.std(X_train)\n",
+    "X_val_scaled = pd.DataFrame(scaler.transform(X_val), columns=X_val.columns)\n",
     "\n",
     "print(X_val_scaled.mean())\n",
     "print('-----------------')\n",
@@ -259,19 +262,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "quality_variation     -571.178878\n",
-      "Air temperature        -41.262937\n",
-      "Process temperature    -48.991056\n",
-      "Rotational speed         6.421100\n",
-      "Torque                 -34.382603\n",
-      "Tool wear               -4.297862\n",
+      "quality_variation     -0.012053\n",
+      "Air temperature        0.002965\n",
+      "Process temperature    0.021866\n",
+      "Rotational speed       0.026043\n",
+      "Torque                -0.008779\n",
+      "Tool wear              0.016080\n",
       "dtype: float64\n",
       "-----------------\n",
       "quality_variation      0.984752\n",
@@ -285,7 +288,7 @@
     }
    ],
    "source": [
-    "X_test_scaled = (X_test - np.mean(X_train))/np.std(X_train)\n",
+    "X_test_scaled = pd.DataFrame(scaler.transform(X_test), columns=X_test.columns)\n",
     "\n",
     "print(X_test_scaled.mean())\n",
     "print('-----------------')\n",
@@ -294,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,13 +323,20 @@
     "| Validation    | (1501, 6) | (1501, 6) |\n",
     "| Test          | (1000, 6) | (1000, 6) |"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.12 (207-pm)",
+   "display_name": "207-pm",
    "language": "python",
-   "name": "207-pm"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -338,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The data scaling script is using np.mean() to get the mean for scaling data, which returns a scalar value aggregating across both features and examples (we only want it to aggregate across examples and return an array).

<img width="1005" height="200" alt="Screenshot 2025-10-13 at 8 44 01 AM" src="https://github.com/user-attachments/assets/2a1aa3f9-b5a4-4ec6-ae60-d046bef1a08a" />

The result is that none of our scaled data is centered on zero.

<img width="498" height="415" alt="Screenshot 2025-10-13 at 8 39 55 AM" src="https://github.com/user-attachments/assets/1c464ef6-f02a-40c1-b901-3552050f4118" />


As shown in the first image, we could fix this by passing `axis=0`, but I decided to use a StandardScaler, which has the same effect.

<img width="609" height="413" alt="Screenshot 2025-10-13 at 8 48 45 AM" src="https://github.com/user-attachments/assets/044c7397-8e81-4d71-8364-d6337c86eec7" />
